### PR TITLE
Fix for 'keys on scalar now forbidden' on Perl >= 5.23

### DIFF
--- a/payload/scripts/ubnt-bcast-relay.pl
+++ b/payload/scripts/ubnt-bcast-relay.pl
@@ -142,7 +142,7 @@ sub restart_daemon {
   my $cfg = shift;
   stop_daemon($cfg);
 
-  for my $relay ( keys $cfg->{relays} ) {
+  for my $relay ( keys %{$cfg->{relays}} ) {
     my $file = $pid_file . q{.} . ${relay} . q{.pid};
     my $cmd
       = qq{start-stop-daemon --start --quiet --background }
@@ -160,7 +160,7 @@ sub restart_daemon {
 sub stop_daemon {
   my $cfg = shift;
 
-  for my $relay ( keys $cfg->{relays} ) {
+  for my $relay ( keys %{$cfg->{relays}} ) {
     my $file = $pid_file . q{.} . ${relay} . q{.pid};
     if ( -f $file ) {
       my $cmd = q{start-stop-daemon --quiet --stop --oknodo --pidfile } . $file;


### PR DESCRIPTION
EdgeRouter f/w v2.0.0 ships with Perl v5.24 which no longer supports the experimental keys on scalar functionality.  Minor fix attached.
