### PR TITLE
Update Readme.md curl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ YMMV and of course, there is always a risk using any non Ubiquiti approved/test 
 
 * upload install_ubnt_bcast_relay.v1.1 to your router
 
-        curl -o /tmp/install_ubnt_bcast_relay.v1.1.tgz https://github.com/britannic/ubnt-bcast-relay/raw/master/ubnt_bcast_relay.1.1.setup.tgz
+        curl -Lo /tmp/install_ubnt_bcast_relay.v1.1.tgz https://github.com/britannic/ubnt-bcast-relay/raw/master/ubnt_bcast_relay.1.1.setup.tgz
         cd /tmp
         sudo tar zxvf ./install_ubnt_bcast_relay.v1.1.tgz
         sudo bash ./install_ubnt_bcast_relay.v1.1


### PR DESCRIPTION
I added the -L to your curl command to have it follow redirects. It looks like github is changing where they store raw data. This just let's curl do the right thing. 

I also noticed that the full path for your build directory is in the tarball. You cannot simply issue ./install_ubnt_bcast_relay.v1.1 because the path is actually /tmp/Users/Neil/perl/src/github.com/ubnt-bcast-relay/install_ubnt_bcast_relay.v1.1. I did not propose any changes for this b/c I did not know if you wanted to fix the documentation or the build process.